### PR TITLE
Extract publication #85

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "readMe",
+  "name": "readme",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -10206,24 +10206,6 @@
         "uuid": "3.2.1"
       }
     },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "4.17.10"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11051,11 +11033,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -10206,6 +10206,24 @@
         "uuid": "3.2.1"
       }
     },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11033,6 +11051,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -49,6 +49,7 @@
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.2.0",
     "request": "^2.85.0",
+    "request-promise-native": "^1.0.5",
     "semantic-ui-react": "^0.80.0",
     "sequelize": "^4.3.1",
     "socket.io": "^2.0.3"

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,8 +1,7 @@
 {
   "name": "readme",
   "version": "1.0.0",
-  "description":
-    "An application which allows users to save articles they wish to read later (via browser extension), and view analytics on their reading habits and preferences.",
+  "description": "An application which allows users to save articles they wish to read later (via browser extension), and view analytics on their reading habits and preferences.",
   "engines": {
     "node": ">= 7.0.0"
   },
@@ -15,12 +14,9 @@
     "postinstall": "touch secrets.js",
     "seed": "node script/seed.js",
     "start": "node server",
-    "start-dev":
-      "NODE_ENV='development' npm run build-client-watch & npm run start-server",
-    "start-server":
-      "nodemon server -e html,js,scss --ignore public --ignore client",
-    "test":
-      "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --require @babel/polyfill --require @babel/register"
+    "start-dev": "NODE_ENV='development' npm run build-client-watch & npm run start-server",
+    "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
+    "test": "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --require @babel/polyfill --require @babel/register"
   },
   "author": "Fullstack Academy of Code",
   "license": "MIT",
@@ -49,7 +45,6 @@
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.2.0",
     "request": "^2.85.0",
-    "request-promise-native": "^1.0.5",
     "semantic-ui-react": "^0.80.0",
     "sequelize": "^4.3.1",
     "socket.io": "^2.0.3"

--- a/web-app/server/api/articles.js
+++ b/web-app/server/api/articles.js
@@ -39,8 +39,8 @@ router.post('/', (req, res, next) => {
   request({ url: articleUrl }, (htmlErr, htmlRes, htmlStr) => {
     if (htmlErr) console.log(htmlErr);
     const publication = getPublicationName(htmlStr);
-    console.log(publication);
-    console.log(htmlRes);
+    console.log('publication: ', publication);
+    console.log('htmlRes: ', htmlRes);
     return publication;
   }).then(publication => {
     // Make Mercury API request on URL received from Chrome extension

--- a/web-app/server/api/articles.js
+++ b/web-app/server/api/articles.js
@@ -4,7 +4,7 @@ module.exports = router;
 const request = require('request-promise-native');
 const MERCURY_API_KEY = process.env.MERCURY_API_KEY;
 const { Article, Author } = require('../db/models');
-const { getPublicationName } = require('../utils');
+const { getPublicationName, getCookieDomain } = require('../utils');
 
 // GET /api/articles
 router.get('/', (req, res, next) => {
@@ -38,12 +38,14 @@ router.post('/', (req, res, next) => {
 
   request({ url: articleUrl }, (htmlErr, htmlRes, htmlStr) => {
     if (htmlErr) console.log(htmlErr);
-    const publication = getPublicationName(htmlStr);
-    console.log('publication: ', publication);
-    console.log('htmlRes: ', htmlRes);
-    return publication;
-  }).then(publication => {
+    const publication1 = getPublicationName(htmlStr)
+      ? getPublicationName(htmlStr)
+      : getCookieDomain(htmlRes.headers['set-cookie'][0]);
+    console.log('publication1: ', publication1);
+    return publication1;
+  }).then(publication2 => {
     // Make Mercury API request on URL received from Chrome extension
+    //console.log('publication2: ', publication2);
     request(mercuryRequestOptions, (apiErr, apiRes, apiBody) => {
       if (apiErr) console.log(apiErr);
       const data = JSON.parse(apiBody);

--- a/web-app/server/utils.js
+++ b/web-app/server/utils.js
@@ -37,11 +37,13 @@ function getDomainFromURLString (urlString) {
 }
 
 function setPublicationName (htmlString, articleUrl) {
+  let publicationName;
   if (getPublicationName(htmlString)) {
-    return getPublicationName(htmlString);
+    publicationName = getPublicationName(htmlString);
   } else {
-    return getDomainFromURLString(articleUrl);
+    publicationName = getDomainFromURLString(articleUrl);
   }
+  return publicationName.split(' - ')[0]; // in case of descriptions in same string, i.e 'Yahoo News - Latest News & Headlines'
 }
 
 module.exports = { setPublicationName, buildMercuryJSONRequest };

--- a/web-app/server/utils.js
+++ b/web-app/server/utils.js
@@ -1,0 +1,30 @@
+function getPublicationName (htmlString) {
+  const metaTagOgSiteName = '<meta property="og:site_name" content="';
+  const metaTagAppName = '<meta name="application-name" content="';
+  const metaStarturl = '<meta name="msapplication-starturl" content="';
+  const ariaLabel = 'aria-label="';
+
+  const nameTests = [
+    metaTagOgSiteName,
+    metaTagAppName,
+    metaStarturl,
+    ariaLabel
+  ];
+
+  for (let i = 0; i < nameTests.length; i++) {
+    if (htmlString.search(nameTests[i]) !== -1) {
+      return extractMetaContent(htmlString, nameTests[i]);
+    }
+  }
+}
+
+function extractMetaContent (htmlStr, metaPattern) {
+  let beginning = htmlStr.search(metaPattern) + metaPattern.length;
+  console.log(beginning);
+  let end = htmlStr.indexOf('"', beginning);
+  console.log(end);
+  console.log(htmlStr.slice(beginning, end));
+  return htmlStr.slice(beginning, end);
+}
+
+module.exports = { getPublicationName };

--- a/web-app/server/utils.js
+++ b/web-app/server/utils.js
@@ -7,28 +7,31 @@ function getPublicationName (htmlString) {
 
   for (let i = 0; i < nameTests.length; i++) {
     if (htmlString.search(nameTests[i]) !== -1) {
-      return extractMetaContent(htmlString, nameTests[i]);
+      return extractMetaContentFromHtml(htmlString, nameTests[i]);
     }
   }
 }
 
-function getCookieDomain (cookieString) {
-  let beginning = cookieString.search('omain=.') + 'omain=.'.length;
-  let end =
-    cookieString.indexOf(';', beginning) !== -1
-      ? cookieString.indexOf(';', beginning)
-      : null;
-  if (end) {
-    return cookieString.slice(beginning, end);
+function extractMetaContentFromHtml (htmlString, metaPattern) {
+  let beginning = htmlString.search(metaPattern) + metaPattern.length;
+  let end = htmlString.indexOf('"', beginning);
+  return htmlString.slice(beginning, end);
+}
+
+function getDomainFromURLString (urlString) {
+  /* got the regex from
+  https://stackoverflow.com/questions/25703360/regular-expression-extract-subdomain-domain
+  */
+  var myRegexp = /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n]+)/gim;
+  return myRegexp.exec(urlString)[1];
+}
+
+function setPublicationName (htmlString, articleUrl) {
+  if (getPublicationName(htmlString)) {
+    return getPublicationName(htmlString);
   } else {
-    return cookieString.slice(beginning);
+    return getDomainFromURLString(articleUrl);
   }
 }
 
-function extractMetaContent (htmlStr, metaPattern) {
-  let beginning = htmlStr.search(metaPattern) + metaPattern.length;
-  let end = htmlStr.indexOf('"', beginning);
-  return htmlStr.slice(beginning, end);
-}
-
-module.exports = { getPublicationName, getCookieDomain };
+module.exports = { setPublicationName };

--- a/web-app/server/utils.js
+++ b/web-app/server/utils.js
@@ -1,3 +1,13 @@
+function buildMercuryJSONRequest (articleUrl) {
+  return {
+    url: `https://mercury.postlight.com/parser?url=${articleUrl}`,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': process.env.MERCURY_API_KEY
+    }
+  };
+}
+
 function getPublicationName (htmlString) {
   const metaTagOgSiteName = '<meta property="og:site_name" content="';
   const metaTagAppName = '<meta name="application-name" content="';
@@ -34,4 +44,4 @@ function setPublicationName (htmlString, articleUrl) {
   }
 }
 
-module.exports = { setPublicationName };
+module.exports = { setPublicationName, buildMercuryJSONRequest };

--- a/web-app/server/utils.js
+++ b/web-app/server/utils.js
@@ -2,14 +2,8 @@ function getPublicationName (htmlString) {
   const metaTagOgSiteName = '<meta property="og:site_name" content="';
   const metaTagAppName = '<meta name="application-name" content="';
   const metaStarturl = '<meta name="msapplication-starturl" content="';
-  const ariaLabel = 'aria-label="';
 
-  const nameTests = [
-    metaTagOgSiteName,
-    metaTagAppName,
-    metaStarturl,
-    ariaLabel
-  ];
+  const nameTests = [metaTagOgSiteName, metaTagAppName, metaStarturl];
 
   for (let i = 0; i < nameTests.length; i++) {
     if (htmlString.search(nameTests[i]) !== -1) {
@@ -18,13 +12,23 @@ function getPublicationName (htmlString) {
   }
 }
 
+function getCookieDomain (cookieString) {
+  let beginning = cookieString.search('omain=.') + 'omain=.'.length;
+  let end =
+    cookieString.indexOf(';', beginning) !== -1
+      ? cookieString.indexOf(';', beginning)
+      : null;
+  if (end) {
+    return cookieString.slice(beginning, end);
+  } else {
+    return cookieString.slice(beginning);
+  }
+}
+
 function extractMetaContent (htmlStr, metaPattern) {
   let beginning = htmlStr.search(metaPattern) + metaPattern.length;
-  console.log(beginning);
   let end = htmlStr.indexOf('"', beginning);
-  console.log(end);
-  console.log(htmlStr.slice(beginning, end));
   return htmlStr.slice(beginning, end);
 }
 
-module.exports = { getPublicationName };
+module.exports = { getPublicationName, getCookieDomain };


### PR DESCRIPTION
Edits in this pull request:
 - Substantial edits to the `Article` model's POST route - before Mercury parses the article, the entire HTML string of the article is requested and then checked for key `<meta>` values that would indicate the publication name. If none found, then the domain name of the provided URL is used.
- Most of this functionality lives in a new `server/utils.js` file.
- Also in this file is a new function for constructing the Mercury request object to make the POST route less bulky.